### PR TITLE
show percent diff to market value in news feed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kickbase-plus",
-  "version": "1.6.0-preview5",
+  "version": "1.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kickbase-plus",
-      "version": "1.6.0-preview5",
+      "version": "1.6.4",
       "license": "MIT",
       "dependencies": {
         "@chenfengyuan/vue-number-input": "^1.2.1",

--- a/src/components/Feed.vue
+++ b/src/components/Feed.vue
@@ -178,33 +178,33 @@ export default {
       let purchaseInfo = null
 
       // purchase info
-      if (item.type === 15 && item.meta && item.meta.b) {
-        const p = numeral(item.meta.v).format('0,0 $')
-        purchaseInfo = `${p}`
+      if (item.type === 15 && item.meta && (item.meta.b || item.meta.s)) {
+        const options = {
+          verb: item.meta.b ? 'paid' : 'sold',
+          over: {
+            color: item.meta.b ? 'red' : 'green',
+            determiner: item.meta.b ? 'more' : 'over',
+          },
+          under: {
+            color: item.meta.b ? 'green' : 'red',
+            determiner: item.meta.b ? 'less' : 'below',
+          },
+        };
+        
+        const price = item.meta.v;
+        const priceFormated = numeral(price).format('0,0 $')
+        purchaseInfo = `${priceFormated}`
 
         if (item.meta.p && this.getPlayers[item.meta.p.i]) {
-          purchaseInfo += ' / MV: ' + numeral(this.getPlayers[item.meta.p.i].marketValue).format('0,0 $')
-          const pp = item.meta.v - this.getPlayers[item.meta.p.i].marketValue
+          const marketValue = this.getPlayers[item.meta.p.i].marketValue;
+          purchaseInfo += ' | MV: ' + numeral(marketValue).format('0,0 $')
+          const pp = item.meta.v - marketValue
+          const ppct = (item.meta.v - marketValue)/marketValue
 
           if (pp > 0) {
-            purchaseInfo += '&nbsp;/&nbsp;<span style="color: red"> paid ' + numeral(pp).format('0,0 $') + ' more than MV</span>'
+            purchaseInfo += `&nbsp;|&nbsp;<span style="color: ${options.over.color}">${options.verb} ${numeral(pp).format('0,0 $')} ${options.over.determiner} MV (${numeral(ppct).format('0.00 %')})</span>`
           } else {
-            purchaseInfo += '&nbsp;/&nbsp;<span style="color: green"> paid ' + numeral(pp).format('0,0 $') + ' less than MV</span>'
-          }
-
-        }
-      } else if (item.type === 15 && item.meta && item.meta.s) {
-        const p = numeral(item.meta.v).format('0,0 $')
-        purchaseInfo = `${p}`
-
-        if (item.meta.p && this.getPlayers[item.meta.p.i]) {
-          purchaseInfo += ' / MV: ' + numeral(this.getPlayers[item.meta.p.i].marketValue).format('0,0 $')
-          const pp = item.meta.v - this.getPlayers[item.meta.p.i].marketValue
-
-          if (pp > 0) {
-            purchaseInfo += '&nbsp;/&nbsp;<span style="color: green"> sold ' + numeral(pp).format('0,0 $') + ' over MV</span>'
-          } else {
-            purchaseInfo += '&nbsp;/&nbsp;<span style="color: red"> sold ' + numeral(pp).format('0,0 $') + ' below MV</span>'
+            purchaseInfo += `&nbsp;|&nbsp;<span style="color: ${options.under.color}">${options.verb} ${numeral(pp).format('0,0 $')} ${options.under.determiner} MV (${numeral(ppct).format('0.00 %')})</span>`
           }
 
         }


### PR DESCRIPTION
This adds some informations in the news feed about bought and sold players. In addition to the absolute difference of the price to the market value this shows also the difference as a percent of the market value.

<img width="765" alt="image" src="https://user-images.githubusercontent.com/4130049/200074657-a40b33dc-4932-492e-a4bc-84c0c5cfb3b8.png">
